### PR TITLE
Add support for additional per pin event options

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -58,6 +58,17 @@ Supported modes:
 - active_low - configures the pin with a pull-up and triggers when it reads 0/low (RECOMMENDED)
 - active_high - configures the pin as a pull-down and triggers when it reads 1/high
 
+Events volume_up and volume_down both support an (optional) "step" option, which controls the amount (in percent) that the volume is adjusted with each button press.
+
+Eg::
+
+    [raspberry-gpio]
+    enabled = true
+    bcm5 = play_pause,active_low,250
+    bcm6 = volume_down,active_low,250,step=1
+    bcm16 = next,active_low,250
+    bcm20 = volume_up,active_low,250,step=1
+
 
 Project resources
 =================

--- a/mopidy_raspberry_gpio/frontend.py
+++ b/mopidy_raspberry_gpio/frontend.py
@@ -51,7 +51,7 @@ class RaspberryGPIOFrontend(pykka.ThreadingActor, core.CoreListener):
     def dispatch_input(self, settings):
         handler_name = f"handle_{settings.event}"
         try:
-            getattr(self, handler_name)(settings.config)
+            getattr(self, handler_name)(settings.options)
         except AttributeError:
             raise RuntimeError(
                 f"Could not find input handler for event: {settings.event}"

--- a/mopidy_raspberry_gpio/pinconfig.py
+++ b/mopidy_raspberry_gpio/pinconfig.py
@@ -12,7 +12,9 @@ class ValidList(list):
 
 
 class PinConfig(config.ConfigValue):
-    tuple_pinconfig = namedtuple("PinConfig", ("event", "active", "bouncetime", "options"))
+    tuple_pinconfig = namedtuple(
+        "PinConfig", ("event", "active", "bouncetime", "options")
+    )
 
     valid_events = ValidList(
         ["play_pause", "prev", "next", "volume_up", "volume_down"]
@@ -31,7 +33,8 @@ class PinConfig(config.ConfigValue):
 
         value = value.split(",")
 
-        if len(value) < 3:  # At least Event, Active and Bouncetime settings required
+        # At least Event, Active and Bouncetime settings required
+        if len(value) < 3:
             return None
 
         event, active, bouncetime = value[0:3]
@@ -64,6 +67,6 @@ class PinConfig(config.ConfigValue):
     def serialize(self, value, display=False):
         if value is None:
             return ""
-        options = ",".join({f'{k}={v}' for k, v in value.options.items()})
-        value = f"{value.event},{value.active},{value.bouncetime}"
+        options = ",".join({f"{k}={v}" for k, v in value.options.items()})
+        value = f"{value.event},{value.active},{value.bouncetime},{options}"
         return types.encode(value)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -59,3 +59,21 @@ def test_pinconfig_invalid_bouncetime_raises_valueerror():
     with pytest.raises(ValueError):
         bcm1 = schema["bcm1"].deserialize("play_pause,active_low,tomato")
         del bcm1
+
+
+def test_pinconfig_additional_options():
+    ext = Extension()
+
+    schema = ext.get_config_schema()
+
+    bcm1 = schema["bcm1"].deserialize("volume_up,active_low,30,steps=1")
+    del bcm1
+
+
+def test_pinconfig_serialize():
+    ext = Extension()
+
+    schema = ext.get_config_schema()
+
+    bcm1 = schema["bcm1"].deserialize("volume_up,active_low,30,steps=1")
+    assert bcm1.serialize() == "volume_up,active_low,30,steps=1"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -76,4 +76,4 @@ def test_pinconfig_serialize():
     schema = ext.get_config_schema()
 
     bcm1 = schema["bcm1"].deserialize("volume_up,active_low,30,steps=1")
-    assert bcm1.serialize() == "volume_up,active_low,30,steps=1"
+    assert schema["bcm1"].serialize(bcm1) == "volume_up,active_low,30,steps=1"

--- a/tests/test_frontend.py
+++ b/tests/test_frontend.py
@@ -4,7 +4,6 @@ from unittest import mock
 import pykka
 from mopidy import core
 
-import pytest
 from mopidy_raspberry_gpio import Extension
 from mopidy_raspberry_gpio import frontend as frontend_lib
 from mopidy_raspberry_gpio import pinconfig
@@ -58,7 +57,11 @@ def test_frontend_handler_dispatch_play_pause():
         dummy_config, dummy_mopidy_core()
     )
 
-    frontend.dispatch_input("play_pause")
+    ext = Extension()
+    schema = ext.get_config_schema()
+    settings = schema["bcm1"].deserialize("play_pause,active_low,30")
+
+    frontend.dispatch_input(settings)
 
     stop_mopidy_core()
 
@@ -71,7 +74,11 @@ def test_frontend_handler_dispatch_next():
         dummy_config, dummy_mopidy_core()
     )
 
-    frontend.dispatch_input("next")
+    ext = Extension()
+    schema = ext.get_config_schema()
+    settings = schema["bcm1"].deserialize("next,active_low,30")
+
+    frontend.dispatch_input(settings)
 
     stop_mopidy_core()
 
@@ -84,7 +91,11 @@ def test_frontend_handler_dispatch_prev():
         dummy_config, dummy_mopidy_core()
     )
 
-    frontend.dispatch_input("prev")
+    ext = Extension()
+    schema = ext.get_config_schema()
+    settings = schema["bcm1"].deserialize("prev,active_low,30")
+
+    frontend.dispatch_input(settings)
 
     stop_mopidy_core()
 
@@ -97,7 +108,11 @@ def test_frontend_handler_dispatch_volume_up():
         dummy_config, dummy_mopidy_core()
     )
 
-    frontend.dispatch_input("volume_up")
+    ext = Extension()
+    schema = ext.get_config_schema()
+    settings = schema["bcm1"].deserialize("volume_up,active_low,30")
+
+    frontend.dispatch_input(settings)
 
     stop_mopidy_core()
 
@@ -110,12 +125,16 @@ def test_frontend_handler_dispatch_volume_down():
         dummy_config, dummy_mopidy_core()
     )
 
-    frontend.dispatch_input("volume_down")
+    ext = Extension()
+    schema = ext.get_config_schema()
+    settings = schema["bcm1"].deserialize("volume_down,active_low,30")
+
+    frontend.dispatch_input(settings)
 
     stop_mopidy_core()
 
 
-def test_frontend_handler_dispatch_invalid_event():
+def test_frontend_handler_dispatch_volume_up_custom_step():
     sys.modules["RPi"] = mock.Mock()
     sys.modules["RPi.GPIO"] = mock.Mock()
 
@@ -123,8 +142,28 @@ def test_frontend_handler_dispatch_invalid_event():
         dummy_config, dummy_mopidy_core()
     )
 
-    with pytest.raises(RuntimeError):
-        frontend.dispatch_input("tomato")
+    ext = Extension()
+    schema = ext.get_config_schema()
+    settings = schema["bcm1"].deserialize("volume_up,active_low,30,step=1")
+
+    frontend.dispatch_input(settings)
+
+    stop_mopidy_core()
+
+
+def test_frontend_handler_dispatch_volume_down_custom_step():
+    sys.modules["RPi"] = mock.Mock()
+    sys.modules["RPi.GPIO"] = mock.Mock()
+
+    frontend = frontend_lib.RaspberryGPIOFrontend(
+        dummy_config, dummy_mopidy_core()
+    )
+
+    ext = Extension()
+    schema = ext.get_config_schema()
+    settings = schema["bcm1"].deserialize("volume_down,active_low,30,step=1")
+
+    frontend.dispatch_input(settings)
 
     stop_mopidy_core()
 


### PR DESCRIPTION
Collect any additional options supplied after the standard "event", "active" and "bouncetime" essentials (in the form "key=value") into an "options" dict on the `pinconfig` tuple.

With changes these options can then be used to supply event-specific modifiers, such as "step" for customising the granularity of volume control.

Building this one phase at a time because the tests will not run on my Python 3.6.x local Ubuntu install in WSL.