### PR TITLE
bugfix: Random occurence of Failed to add edge detection

### DIFF
--- a/mopidy_raspberry_gpio/frontend.py
+++ b/mopidy_raspberry_gpio/frontend.py
@@ -47,16 +47,19 @@ class RaspberryGPIOFrontend(pykka.ThreadingActor, core.CoreListener):
                         self.rot_encoders[rotenc_id] = encoder
                     encoder.add_pin(pin, settings.event)
 
-                GPIO.setup(pin, GPIO.IN, pull_up_down=pull)
+                try:
+                    GPIO.setup(pin, GPIO.IN, pull_up_down=pull)
 
-                GPIO.add_event_detect(
-                    pin,
-                    edge,
-                    callback=self.gpio_event,
-                    bouncetime=settings.bouncetime,
-                )
+                    GPIO.add_event_detect(
+                        pin,
+                        edge,
+                        callback=self.gpio_event,
+                        bouncetime=settings.bouncetime,
+                    )
 
-                self.pin_settings[pin] = settings
+                    self.pin_settings[pin] = settings
+                except:
+                    logger.error(f"GPIO setup failed for pin {key}")
 
         # TODO validate all self.rot_encoders have two pins
 


### PR DESCRIPTION
Sometimes a GPIO pin will fail to setup (RuntimeError: Failed to add edge detection). It was hard to know which pin gave the error. 
With this improvement the problematic pin number is logged and the plugin will continue to work for all other pins instead of stopping.
Also try multiple times to set the event, as the error can occur randomly due to an error in PRi.GPIO, even if the pin is not in use.
Tested on a Rpi Zero W with latest Raspbian-lite.