### PR TITLE
Update readme to reflect change in BCM numbering in newer Pi's

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,9 +48,9 @@ Mopidy-Raspberry-GPIO to your Mopidy configuration file::
     bcm6 = prev,active_low,250
     bcm16 = next,active_low,250
     bcm21 = volume_down,active_low,10,rotenc_id=vol,step=1
-    bcm20 = volume_up,active_low,10,rotenc_id=vol,step=1
+    bcm24 = volume_up,active_low,10,rotenc_id=vol,step=1
 
-Each bcmN entry corresponds to the BCM pin of that number.
+Each bcmN entry corresponds to the BCM pin of that number.  Note: Older Pi's use `bcm20` instead of `bcm24`.
 
 You must assign an event, mode and bouncetime (ms) to your desired pins.
 
@@ -76,7 +76,7 @@ Eg::
     bcm5 = play_pause,active_low,250
     bcm6 = volume_down,active_low,250,step=1
     bcm16 = next,active_low,250
-    bcm20 = volume_up,active_low,250,step=1
+    bcm24 = volume_up,active_low,250,step=1
 
 
 Project resources


### PR DESCRIPTION
This PR updates the README.rst to reflect a change made to GPIO pin numbering.  On current hardware, the Y button maps to `BCM24`.  I found this information [here](https://pinout.xyz/pinout/pirate_audio_3w_amp#).  I am unable to find exactly which models reflect this change, but all current documentation found [here](https://www.raspberrypi.com/documentation/computers/raspberry-pi.html#schematics-and-mechanical-drawings) indicates physical pin 18 is always `BCM24`.