### PR TITLE
Adding functionality to allow to go previous by long pressing X

### DIFF
--- a/mopidy_raspberry_gpio/frontend.py
+++ b/mopidy_raspberry_gpio/frontend.py
@@ -6,7 +6,7 @@ from mopidy import core
 from .rotencoder import RotEncoder
 
 logger = logging.getLogger(__name__)
-
+import time
 
 class RaspberryGPIOFrontend(pykka.ThreadingActor, core.CoreListener):
     def __init__(self, config, core):
@@ -66,12 +66,26 @@ class RaspberryGPIOFrontend(pykka.ThreadingActor, core.CoreListener):
                 return encoder
 
     def gpio_event(self, pin):
+        import RPi.GPIO as GPIO  # Import GPIO module here
         settings = self.pin_settings[pin]
         event = settings.event
         encoder = self.find_pin_rotenc(pin)
+
+        # Check button press duration for Pin 16
+        if pin == 16:
+            start_time = time.time()
+            while GPIO.input(pin) == GPIO.LOW:
+                time.sleep(0.1)
+            end_time = time.time()
+            press_duration = end_time - start_time
+
+            if press_duration < 1:
+                event = "next"
+            else:
+                event = "prev"
+
         if encoder:
             event = encoder.get_event()
-
         if event:
             self.dispatch_input(event, settings.options)
 


### PR DESCRIPTION
This pull request introduces a new feature for the Raspberry GPIO Frontend. It modifies the button event handling logic for Pin 16 as follows:

1.     A short press (less than 2 seconds) on Pin 16 triggers the handle_next function.
2.     A long press (2 seconds or more) on Pin 16 triggers the handle_prev function.

This logic ensures that only one event is triggered based on the duration of the button press, preventing multiple events from disturbing the playlist.

Changes Made

    Modified the gpio_event method to handle button press duration for Pin 16.
    Implemented logic to trigger handle_next for short presses and handle_prev for long presses on Pin 16.

Important! Make sure Mopidy or mpc has repeat off, otherwise you don't go previous but to start of song.