### PR TITLE
Add playlist support

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,6 +61,7 @@ Supported events:
 - volume_down
 - next
 - prev
+- playlist
 
 Supported modes:
 
@@ -78,6 +79,15 @@ Eg::
     bcm16 = next,active_low,250
     bcm20 = volume_up,active_low,250,step=1
 
+The playlist event allows to assign a playlist to a physical button. It requires an "uri" option. It first clears the tracklist, adds all tracks from the playlist and starts playback. 
+
+Eg::
+
+    [raspberry-gpio]
+    enabled = true
+    bcm17 = playlist,active_low,250,uri=m3u:test1.m3u8
+
+Hint: If you use the `Iris frontend <https://github.com/jaedb/Iris>`_, you can obtain the playlist URI in the tree-dots menu of the playlist.
 
 Project resources
 =================

--- a/mopidy_raspberry_gpio/pinconfig.py
+++ b/mopidy_raspberry_gpio/pinconfig.py
@@ -17,7 +17,15 @@ class PinConfig(config.ConfigValue):
     )
 
     valid_events = ValidList(
-        ["play_pause", "play_stop", "prev", "next", "volume_up", "volume_down"]
+        [
+            "play_pause",
+            "play_stop",
+            "prev",
+            "next",
+            "volume_up",
+            "volume_down",
+            "playlist",
+        ]
     )
 
     valid_modes = ValidList(["active_low", "active_high"])
@@ -61,6 +69,9 @@ class PinConfig(config.ConfigValue):
         for option in value[3:]:
             key, value = option.split("=")
             options[key] = value
+
+        if event == "playlist" and not "uri" in options:
+            raise ValueError(f'no "uri" option given for playlist')
 
         return self.tuple_pinconfig(event, active, bouncetime, options)
 


### PR DESCRIPTION
From the updated README:

The playlist event allows to assign a playlist to a physical button. It requires an "uri" option. It first clears the tracklist, adds all tracks from the playlist and starts playback. 

Eg::

    [raspberry-gpio]
    enabled = true
    bcm17 = playlist,active_low,250,uri=m3u:test1.m3u8

Hint: If you use the `Iris frontend <https://github.com/jaedb/Iris>`_, you can obtain the playlist URI in the tree-dots menu of the playlist.